### PR TITLE
2008/2010: remove extra lines from end of files

### DIFF
--- a/2010/20101102__mo__general__precinct.csv
+++ b/2010/20101102__mo__general__precinct.csv
@@ -71663,5 +71663,3 @@ WRIGHT,0013 MANES,State House,144,REP,Dugger,Tony,248
 WRIGHT,0015 GROVESPRING,State House,144,REP,Dugger,Tony,500
 WRIGHT,0998 FEDERAL,State House,144,REP,Dugger,Tony,0
 WRIGHT,0999 ABSENTEE,State House,144,REP,Dugger,Tony,307
-,,,,,,,
-(71664 row(s) affected),,,,,,,


### PR DESCRIPTION
Extra text at the bottom of these files