### PR TITLE
Bump data tests to version 2.1.0

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-data-tests
-        ref: v2.0.0
+        ref: v2.1.0
         path: data_tests
 
     - name: Run data tests


### PR DESCRIPTION
This bumps the data tests to [version 2.1.0](https://github.com/openelections/openelections-data-tests/releases/tag/v2.1.0).